### PR TITLE
strip content-encoding header when processing response

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -192,7 +192,8 @@ def process_response(response, url):
 
 	response = Response(content, status_code)
 	for key, value in headers.items():
-		response.headers[key] = value
+		if key.lower() != 'content-encoding':
+			response.headers[key] = value
 
 	print("Finished processing response")
 	return response

--- a/proxy.py
+++ b/proxy.py
@@ -192,7 +192,7 @@ def process_response(response, url):
 
 	response = Response(content, status_code)
 	for key, value in headers.items():
-		if key.lower() != 'content-encoding':
+		if key.lower() not in ['content-encoding', 'content-length']:
 			response.headers[key] = value
 
 	print("Finished processing response")


### PR DESCRIPTION
Not sure what the best way is to handle unsupported headers, but I was getting a lot of "unsupported content type: gzip" in Netscape. I think the proxied responses aren't compressed anyway, so it should be fine to always strip the content encoding header.