### PR TITLE
Implement presets

### DIFF
--- a/extensions/waybackmachine/requirements.txt
+++ b/extensions/waybackmachine/requirements.txt
@@ -1,1 +1,0 @@
-waybackpy

--- a/presets/macweb2/macweb2.py
+++ b/presets/macweb2/macweb2.py
@@ -1,58 +1,5 @@
-# To enable extensions, rename this file to "config.py"
-# and fill in the necessary API keys and other details.
-
-# Store API keys and other configuration details here:
-# OPEN_AI_API_KEY = "YOUR_OPENAI_API_KEY_HERE"
-# ANTHROPIC_API_KEY = "YOUR_ANTHROPIC_API_KEY_HERE"
-# MISTRAL_API_KEY = "YOUR_MISTRAL_API_KEY_HERE"
-# KAGI_SESSION_TOKEN = "YOUR_KAGI_SESSION_TOKEN_HERE"
-
-# Used by weather extension (which currently only works for United States)
-# ZIP_CODE = "YOUR_ZIP_CODE"
-
-# Uncomment lines to enable desired extensions:
-ENABLED_EXTENSIONS = [
-	#"chatgpt",
-	#"claude",
-	#"hackaday",
-	#"hacksburg",
-	#"hunterirving",
-	#"kagi",
-	#"mistral",
-	#"notyoutube"
-	#"npr",
-	#"reddit",
-	#"waybackmachine",
-	#"weather",
-	#"websimulator",
-	#"wiby",
-	#"wikipedia",
-]
-
-# While SIMPLIFY_HTML is True, you can use WHITELISTED_DOMAINS to disable post-processing for
-# specific sites (only perform HTTPS -> HTTP conversion and character conversion (if CONVERT_CHARACTERS is True),
-# without otherwise modifying the page's source code).
-WHITELISTED_DOMAINS = [
-	#"example.com",
-]
-
-# Optionally, load a preset (.py file) from /presets, optimized for compatibility
-# with a specific web browser. Enabling a preset may override one or more of the
-# settings that follow below.
-# The default values target compatability with the MacWeb 2.0 browser.
-#PRESET = "wii_internet_channel"
-
-# --------------------------------------------------------------------------------------
-# *** One or more of the following settings may be overridden if you enable a preset ***
-# --------------------------------------------------------------------------------------
-
-# If True, parse HTML responses to strip specified tags and attributes.
-# If False, always return the full, unmodified HTML as served by the requested site or extension
-# (only perform HTTPS -> HTTP conversion and character conversion (if CONVERT_CHARACTERS is True),
-# without otherwise modifying the page's source code).
 SIMPLIFY_HTML = True
 
-# If SIMPLIFY_HTML is True, strip these HTML tags during processing:
 TAGS_TO_STRIP = [
 	"script",
 	"link",
@@ -61,7 +8,6 @@ TAGS_TO_STRIP = [
 	"meta"
 ]
 
-# If SIMPLIFY_HTML is True, strip these HTML attributes during processing:
 ATTRIBUTES_TO_STRIP = [
 	"style",
 	"onclick",
@@ -72,16 +18,14 @@ ATTRIBUTES_TO_STRIP = [
 	"vlink"
 ]
 
-# Process images for optimal rendering on your device/browser:
-CAN_RENDER_INLINE_IMAGES = False # Mostly used to conditionally enable landing page images (ex: waybackmachine.py)
+CAN_RENDER_INLINE_IMAGES = False
 RESIZE_IMAGES = True
-MAX_IMAGE_WIDTH = 512 # Only used if RESIZE_IMAGES is True
-MAX_IMAGE_HEIGHT = 342 # Only used if RESIZE_IMAGES is True
+MAX_IMAGE_WIDTH = 512
+MAX_IMAGE_HEIGHT = 342
 CONVERT_IMAGES = True
-CONVERT_IMAGES_TO_FILETYPE = "gif" # Only used if CONVERT_IMAGES is True
-DITHERING_ALGORITHM = "FLOYDSTEINBERG" # Only used if CONVERT_IMAGES is True and CONVERT_IMAGES_TO_FILETYPE == "gif"
+CONVERT_IMAGES_TO_FILETYPE = "gif"
+DITHERING_ALGORITHM = "FLOYDSTEINBERG"
 
-# In addition to the default web simulator prompt, add custom instructions to improve compatability with your web browser.
 WEB_SIMULATOR_PROMPT_ADDENDUM = """<formatting>
 IMPORTANT: The user's web browser only supports (most of) HTML 3.2 (you do not need to acknowledge this to the user, only understand it and use this knowledge to construct the HTML you respond with).
 Their browser has NO CSS support and NO JavaScript support. Never include <script>, <style> or inline scripting or styling in your responses. The output html will always be rendered as black on a white background, and there's no need to try to change this.
@@ -101,10 +45,8 @@ hr - always format like <hr>, and never like <hr />, as this is not supported by
 Never use script tags or style tags.
 </formatting>"""
 
-# Conditionally enable/disable use of CONVERSION_TABLE
 CONVERT_CHARACTERS = True
 
-# Convert text characters for compatability with specific browsers
 CONVERSION_TABLE = {
 	"¢": b"cent",
 	"&cent;": b"cent",

--- a/presets/wii_internet_channel/wii_internet_channel.py
+++ b/presets/wii_internet_channel/wii_internet_channel.py
@@ -1,0 +1,195 @@
+SIMPLIFY_HTML = False
+
+TAGS_TO_STRIP = []
+
+ATTRIBUTES_TO_STRIP = []
+
+CAN_RENDER_INLINE_IMAGES = True
+RESIZE_IMAGES = False
+MAX_IMAGE_WIDTH = None
+MAX_IMAGE_HEIGHT = None
+CONVERT_IMAGES = False
+CONVERT_IMAGES_TO_FILETYPE = None
+DITHERING_ALGORITHM = None
+
+WEB_SIMULATOR_PROMPT_ADDENDUM = """<formatting>
+The user is accessing these pages from a Nintendo Wii running the Internet Channel, a simplified version of the Opera browser designed specially for the Wii.
+This browser was released in 2006, and has the following features and quirks (keep these in mind when generating web pages):
+Opera supports all the elements and attributes of HTML4.01 with the following exceptions:
+	<input type="file"> is not supported.
+	The col width attribute does not support multilengths.
+	The object standby and declare attributes are not supported.
+	The table cell attributes char and charoff are not supported.
+Opera supports the canvas element.
+Opera has experimental support for the Web Forms 2.0 extension to HTML4.
+Opera supports all of CSS2 except where behavior has been modified / changed by CSS2.1. There are some limitations to Opera's support for CSS:
+	The following properties are not supported:
+		font-size-adjust
+		font-stretch
+		marker-offset
+		marks
+		text-shadow (supported as -o-text-shadow)
+	The following property / value combinations are not supported:
+		display:marker
+		text-align:<string>
+		visibility:collapse
+		white-space:pre-line
+	Named pages (as described in section 13.3.2).
+	The @font-face construct.
+CSS3:
+Opera has partial support for the Selectors and Media Queries specifications. Opera also supports the content property on arbitrary elements and not just on ::before and ::after. It also supports the following properties:
+    box-sizing
+    opacity
+Opera CSS extensions:
+Opera implements several CSS3 properties as experimental properties so authors can try them out. By implementing them with the -o- prefix we ensure that the specification can be changed at a later stage:
+    -o-text-overflow:ellipsis
+    -o-text-shadow
+Opera supports the entire ECMA-262 2ed and 3ed standards, with no exceptions. They are more or less aligned with JavaScript 1.3/1.5.
+All text communicated to Opera from the network is converted into Unicode.
+Opera supports a superset of SVG 1.1 Basic and SVG 1.1 Tiny with some exceptions. This maps to a partial support of SVG 1.1.
+Event listening to any event is supported, but some events are not fired by the application. focusin, focusout and activate for instance. Fonts are supported, including font-family, but if there is a missing glyph in the selected font a platform-defined fallback will be used instead of picking that glyph from the next font in line in the font-family property.
+SVG can be used in object, embed, and iframe in HTML and as stand-alone document. It is not supported for img elements or in CSS property values (e.g. background-image). An SVG image element can contain any supported raster graphics, but not another SVG image. References to external resources are not supported.
+These features are particularly processor expensive and should be used with care when targetting machines with slower processors: filters, transparency layers (group opacity), and masks.
+</formatting>
+<expressiveness>
+Use CSS and JavaScript liberally (while minding the supported versions of each) to surprise and delight the user with exciting, interactive webpages. Push the limits of what is expected to create interfaces that are fun, innovative, and experimental.
+You should always embed CSS/JS within the returned HTML file, either inline or within <style> and/or <script> tags.
+</expressiveness>
+"""
+
+CONVERT_CHARACTERS = True
+CONVERSION_TABLE = {
+	"¢": b"cent",
+	"&cent;": b"cent",
+	"€": b"EUR",
+	"&euro;": b"EUR",
+	"&yen;": b"YEN",
+	"&pound;": b"GBP",
+	"«": b"'",
+	"&laquo;": b"'",
+	"»": b"'",
+	"&raquo;": b"'",
+	"‘": b"'",
+	"&lsquo;": b"'",
+	"’": b"'",
+	"&rsquo;": b"'",
+	"“": b"''",
+	"&ldquo;": b"''",
+	"”": b"''",
+	"&rdquo;": b"''",
+	"–": b"-",
+	"&ndash;": b"-",
+	"—": b"--",
+	"&mdash;": b"--",
+	"―": b"-",
+	"&horbar;": b"-",
+	"·": b"-",
+	"&middot;": b"-",
+	"‚": b",",
+	"&sbquo;": b",",
+	"„": b",,",
+	"&bdquo;": b",,",
+	"†": b"*",
+	"&dagger;": b"*",
+	"‡": b"**",
+	"&Dagger;": b"**",
+	"•": b"-",
+	"&bull;": b"*",
+	"…": b"...",
+	"&hellip;": b"...",
+	"\u00A0": b" ",
+	"&nbsp;": b" ",
+	"±": b"+/-",
+	"&plusmn;": b"+/-",
+	"≈": b"~",
+	"&asymp;": b"~",
+	"≠": b"!=",
+	"&ne;": b"!=",
+	"&times;": b"x",
+	"⁄": b"/",
+	"°": b"*",
+	"&deg;": b"*",
+	"′": b"'",
+	"&prime;": b"'",
+	"″": b"''",
+	"&Prime;": b"''",
+	"™": b"(tm)",
+	"&trade;": b"(TM)",
+	"&reg;": b"(R)",
+	"®": b"(R)",
+	"&copy;": b"(c)",
+	"©": b"(c)",
+	"é": b"e",
+	"ø": b"o",
+	"Å": b"A",
+	"â": b"a",
+	"Æ": b"AE",
+	"æ": b"ae",
+	"á": b"a",
+	"ō": b"o",
+	"ó": b"o",
+	"ū": b"u",
+	"⟨": b"<",
+	"⟩": b">",
+	"←": b"<",
+	"›": b">",
+	"‹": b"<",
+	"&larr;": b"<",
+	"→": b">",
+	"&rarr;": b">",
+	"↑": b"^",
+	"&uarr;": b"^",
+	"↓": b"v",
+	"&darr;": b"v",
+	"↖": b"\\",
+	"&nwarr;": b"\\",
+	"↗": b"/",
+	"&nearr;": b"/",
+	"↘": b"\\",
+	"&searr;": b"\\",
+	"↙": b"/",
+	"&swarr;": b"/",
+	"─": b"-",
+	"&boxh;": b"-",
+	"│": b"|",
+	"&boxv;": b"|",
+	"┌": b"+",
+	"&boxdr;": b"+",
+	"┐": b"+",
+	"&boxdl;": b"+",
+	"└": b"+",
+	"&boxur;": b"+",
+	"┘": b"+",
+	"&boxul;": b"+",
+	"├": b"+",
+	"&boxvr;": b"+",
+	"┤": b"+",
+	"&boxvl;": b"+",
+	"┬": b"+",
+	"&boxhd;": b"+",
+	"┴": b"+",
+	"&boxhu;": b"+",
+	"┼": b"+",
+	"&boxvh;": b"+",
+	"█": b"#",
+	"&block;": b"#",
+	"▌": b"|",
+	"&lhblk;": b"|",
+	"▐": b"|",
+	"&rhblk;": b"|",
+	"▀": b"-",
+	"&uhblk;": b"-",
+	"▄": b"_",
+	"&lhblk;": b"_",
+	"▾": b"v",
+	"&dtrif;": b"v",
+	"&#x25BE;": b"v",
+	"&#9662;": b"v",
+	"♫": b"",
+	"&spades;": b"",
+	"\u200B": b"",
+	"&ZeroWidthSpace;": b"",
+	"\u200C": b"",
+	"\u200D": b"",
+	"\uFEFF": b"",
+}

--- a/proxy.py
+++ b/proxy.py
@@ -38,8 +38,8 @@ try:
 	import config
 	ENABLED_EXTENSIONS = config.ENABLED_EXTENSIONS
 except ModuleNotFoundError:
-	print("config.py not found, running without extensions")
-	ENABLED_EXTENSIONS = []
+	print("config.py not found, exiting.")
+	quit()
 
 # Load extensions
 extensions = {}
@@ -176,6 +176,9 @@ def process_response(response, url):
 		'application/msword',
 		'audio/',
 		'video/',
+		'text/javascript',
+		'text/css',
+		'text/plain'
 	]
 
 	# Check if content type is in the list of non-transcode types
@@ -186,7 +189,7 @@ def process_response(response, url):
 		if isinstance(content, bytes):
 			content = content.decode('utf-8', errors='replace')
 		
-		content = transcode_html(content, app.config["DISABLE_CHAR_CONVERSION"])
+		content = transcode_html(content)
 	else:
 		print(f"Content type {content_type} should not be transcoded, passing through unchanged")
 
@@ -263,12 +266,5 @@ if __name__ == "__main__":
 		action="store",
 		help="The BeautifulSoup html formatter that Macproxy will use",
 	)
-	parser.add_argument(
-		"--disable-char-conversion",
-		action="store_true",
-		help="Disable the conversion of common typographic characters to ASCII",
-	)
 	arguments = parser.parse_args()
-	app.config["USER_AGENT"] = arguments.user_agent
-	app.config["DISABLE_CHAR_CONVERSION"] = arguments.disable_char_conversion
 	app.run(host="0.0.0.0", port=arguments.port, debug=False)

--- a/proxy.py
+++ b/proxy.py
@@ -2,7 +2,7 @@ import os
 import requests
 import argparse
 from flask import Flask, request, session, g, abort, Response, send_from_directory
-from utils.html_utils import transcode_html
+from utils.html_utils import transcode_html, transcode_content
 from urllib.parse import urlparse, urljoin
 from bs4 import BeautifulSoup
 import io
@@ -159,6 +159,13 @@ def process_response(response, url):
 		else:
 			return abort(404, "Image could not be processed")
 
+	# Handle CSS and JavaScript
+	if content_type in ['text/css', 'text/javascript', 'application/javascript', 'application/x-javascript']:
+		content = transcode_content(content)
+		response = Response(content, status_code)
+		response.headers['Content-Type'] = content_type
+		return response
+
 	# List of content types that should not be transcoded
 	non_transcode_types = [
 		'application/octet-stream',
@@ -176,8 +183,6 @@ def process_response(response, url):
 		'application/msword',
 		'audio/',
 		'video/',
-		'text/javascript',
-		'text/css',
 		'text/plain'
 	]
 

--- a/proxy.py
+++ b/proxy.py
@@ -194,7 +194,7 @@ def process_response(response, url):
 		if isinstance(content, bytes):
 			content = content.decode('utf-8', errors='replace')
 		
-		content = transcode_html(content)
+		content = transcode_html(content, url)
 	else:
 		print(f"Content type {content_type} should not be transcoded, passing through unchanged")
 

--- a/utils/html_utils.py
+++ b/utils/html_utils.py
@@ -2,142 +2,7 @@ from bs4 import BeautifulSoup
 from bs4.formatter import HTMLFormatter
 import re
 import html
-
-CONVERSION_TABLE = {
-	"¢": b"cent",
-	"&cent;": b"cent",
-	"€": b"EUR",
-	"&euro;": b"EUR",
-	"&yen;": b"YEN",
-	"&pound;": b"GBP",
-	"«": b"'",
-	"&laquo;": b"'",
-	"»": b"'",
-	"&raquo;": b"'",
-	"‘": b"'",
-	"&lsquo;": b"'",
-	"’": b"'",
-	"&rsquo;": b"'",
-	"“": b"''",
-	"&ldquo;": b"''",
-	"”": b"''",
-	"&rdquo;": b"''",
-	"–": b"-",
-	"&ndash;": b"-",
-	"—": b"--",
-	"&mdash;": b"--",
-	"―": b"-",
-	"&horbar;": b"-",
-	"·": b"-",
-	"&middot;": b"-",
-	"‚": b",",
-	"&sbquo;": b",",
-	"„": b",,",
-	"&bdquo;": b",,",
-	"†": b"*",
-	"&dagger;": b"*",
-	"‡": b"**",
-	"&Dagger;": b"**",
-	"•": b"-",
-	"&bull;": b"*",
-	"…": b"...",
-	"&hellip;": b"...",
-	"\u00A0": b" ",
-	"&nbsp;": b" ",
-	"±": b"+/-",
-	"&plusmn;": b"+/-",
-	"≈": b"~",
-	"&asymp;": b"~",
-	"≠": b"!=",
-	"&ne;": b"!=",
-	"&times;": b"x",
-	"⁄": b"/",
-	"°": b"*",
-	"&deg;": b"*",
-	"′": b"'",
-	"&prime;": b"'",
-	"″": b"''",
-	"&Prime;": b"''",
-	"™": b"(tm)",
-	"&trade;": b"(TM)",
-	"&reg;": b"(R)",
-	"®": b"(R)",
-	"&copy;": b"(c)",
-	"©": b"(c)",
-	"é": b"e",
-	"ø": b"o",
-	"Å": b"A",
-	"â": b"a",
-	"Æ": b"AE",
-	"æ": b"ae",
-	"á": b"a",
-	"ō": b"o",
-	"ó": b"o",
-	"ū": b"u",
-	"⟨": b"<",
-	"⟩": b">",
-	"←": b"<",
-	"›": b">",
-	"‹": b"<",
-	"&larr;": b"<",
-	"→": b">",
-	"&rarr;": b">",
-	"↑": b"^",
-	"&uarr;": b"^",
-	"↓": b"v",
-	"&darr;": b"v",
-	"↖": b"\\",
-	"&nwarr;": b"\\",
-	"↗": b"/",
-	"&nearr;": b"/",
-	"↘": b"\\",
-	"&searr;": b"\\",
-	"↙": b"/",
-	"&swarr;": b"/",
-	"─": b"-",
-	"&boxh;": b"-",
-	"│": b"|",
-	"&boxv;": b"|",
-	"┌": b"+",
-	"&boxdr;": b"+",
-	"┐": b"+",
-	"&boxdl;": b"+",
-	"└": b"+",
-	"&boxur;": b"+",
-	"┘": b"+",
-	"&boxul;": b"+",
-	"├": b"+",
-	"&boxvr;": b"+",
-	"┤": b"+",
-	"&boxvl;": b"+",
-	"┬": b"+",
-	"&boxhd;": b"+",
-	"┴": b"+",
-	"&boxhu;": b"+",
-	"┼": b"+",
-	"&boxvh;": b"+",
-	"█": b"#",
-	"&block;": b"#",
-	"▌": b"|",
-	"&lhblk;": b"|",
-	"▐": b"|",
-	"&rhblk;": b"|",
-	"▀": b"-",
-	"&uhblk;": b"-",
-	"▄": b"_",
-	"&lhblk;": b"_",
-	"▾": b"v",
-	"&dtrif;": b"v",
-	"&#x25BE;": b"v",
-	"&#9662;": b"v",
-	"♫": b"",
-	"&spades;": b"",
-	"\u200B": b"",
-	"&ZeroWidthSpace;": b"",
-	"\u200C": b"",
-	"\u200D": b"",
-	"\uFEFF": b"",
-}
+from config import WHITELISTED_DOMAINS, SIMPLIFY_HTML, TAGS_TO_STRIP, ATTRIBUTES_TO_STRIP, CONVERT_CHARACTERS, CONVERSION_TABLE
 
 class URLAwareHTMLFormatter(HTMLFormatter):
 	def __init__(self, *args, **kwargs):
@@ -161,14 +26,14 @@ class URLAwareHTMLFormatter(HTMLFormatter):
 			else:
 				yield key, self.escape(val)
 
-def transcode_html(html, disable_char_conversion):
+def transcode_html(html):
 	"""
 	Uses BeautifulSoup to transcode payloads of the text/html content type
 	"""
 	if isinstance(html, bytes):
 		html = html.decode("utf-8", errors="replace")
 
-	if not disable_char_conversion:
+	if CONVERT_CHARACTERS:
 		for key, replacement in CONVERSION_TABLE.items():
 			if isinstance(replacement, bytes):
 				replacement = replacement.decode("utf-8")
@@ -176,16 +41,13 @@ def transcode_html(html, disable_char_conversion):
 
 	soup = BeautifulSoup(html, "html.parser")
 	
-	# Remove all class attributes to make pages load faster
-	for tag in soup.find_all(class_=True):
-		del tag['class']
-	
-	for tag in soup(["script", "link", "style", "source", "picture"]):
-		tag.decompose()
-	for tag in soup():
-		for attr in ["style", "onclick"]:
-			if attr in tag.attrs:
-				del tag[attr]
+	if SIMPLIFY_HTML:
+		for tag in soup(TAGS_TO_STRIP):
+			tag.decompose()
+		for tag in soup():
+			for attr in ATTRIBUTES_TO_STRIP:
+				if attr in tag.attrs:
+					del tag[attr]
 	for tag in soup(["base", "a"]):
 		if "href" in tag.attrs:
 			tag["href"] = tag["href"].replace("https://", "http://")

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -5,7 +5,6 @@ import hashlib
 import requests
 from PIL import Image
 import mimetypes
-from config import MAX_IMAGE_HEIGHT, MAX_IMAGE_WIDTH, RESIZE_IMAGES, CONVERT_IMAGES, CONVERT_IMAGES_TO_FILETYPE, DITHERING_ALGORITHM
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), "cached_images")
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
@@ -14,7 +13,8 @@ def is_image_url(url):
 	mime_type, _ = mimetypes.guess_type(url)
 	return mime_type and mime_type.startswith('image/')
 
-def optimize_image(image_data):
+def optimize_image(image_data, resize=True, max_width=512, max_height=342, 
+				  convert=True, convert_to='gif', dithering='FLOYDSTEINBERG'):
 	try:
 		img = Image.open(io.BytesIO(image_data))
 		
@@ -27,26 +27,26 @@ def optimize_image(image_data):
 			img = img.convert('RGB')
 		
 		# Resize if enabled and necessary
-		if RESIZE_IMAGES:
+		if resize and max_width and max_height:
 			width, height = img.size
-			if width > MAX_IMAGE_WIDTH or height > MAX_IMAGE_HEIGHT:
-				ratio = min(MAX_IMAGE_WIDTH / width, MAX_IMAGE_HEIGHT / height)
+			if width > max_width or height > max_height:
+				ratio = min(max_width / width, max_height / height)
 				new_size = (int(width * ratio), int(height * ratio))
 				img = img.resize(new_size, Image.Resampling.LANCZOS)
 		
 		# Convert format if enabled
-		if CONVERT_IMAGES:
-			if CONVERT_IMAGES_TO_FILETYPE.lower() == 'gif':
+		if convert and convert_to:
+			if convert_to.lower() == 'gif':
 				# For black and white GIF
 				img = img.convert("L")  # Convert to grayscale first
-				dither_method = Image.Dither.FLOYDSTEINBERG if DITHERING_ALGORITHM.upper() == 'FLOYDSTEINBERG' else None
+				dither_method = Image.Dither.FLOYDSTEINBERG if dithering and dithering.upper() == 'FLOYDSTEINBERG' else None
 				img = img.convert("1", dither=dither_method)
 			else:
 				# For other format conversions
 				img = img.convert(img.mode)
 		
 		output = io.BytesIO()
-		save_format = CONVERT_IMAGES_TO_FILETYPE.upper() if CONVERT_IMAGES else img.format
+		save_format = convert_to.upper() if convert and convert_to else img.format
 		img.save(output, format=save_format, optimize=True)
 		return output.getvalue()
 		
@@ -54,12 +54,13 @@ def optimize_image(image_data):
 		print(f"Error optimizing image: {str(e)}")
 		return image_data
 
-def fetch_and_cache_image(url, content=None):
+def fetch_and_cache_image(url, content=None, resize=True, max_width=512, max_height=342,
+						 convert=True, convert_to='gif', dithering='FLOYDSTEINBERG'):
 	try:
 		print(f"Processing image: {url}")
 		
 		# Generate filename with appropriate extension
-		extension = CONVERT_IMAGES_TO_FILETYPE.lower() if CONVERT_IMAGES else "gif"
+		extension = convert_to.lower() if convert and convert_to else "gif"
 		file_name = hashlib.md5(url.encode()).hexdigest() + f".{extension}"
 		file_path = os.path.join(CACHE_DIR, file_name)
 		
@@ -70,9 +71,17 @@ def fetch_and_cache_image(url, content=None):
 				response.raise_for_status()
 				content = response.content
 			
-			# Only process if image conversion is enabled
-			if CONVERT_IMAGES or RESIZE_IMAGES:
-				optimized_image = optimize_image(content)
+			# Only process if image conversion or resizing is enabled
+			if convert or resize:
+				optimized_image = optimize_image(
+					content,
+					resize=resize,
+					max_width=max_width,
+					max_height=max_height,
+					convert=convert,
+					convert_to=convert_to,
+					dithering=dithering
+				)
 			else:
 				optimized_image = content
 				

--- a/utils/image_utils.py
+++ b/utils/image_utils.py
@@ -1,65 +1,94 @@
+
 import os
 import io
 import hashlib
 import requests
 from PIL import Image
 import mimetypes
+from config import MAX_IMAGE_HEIGHT, MAX_IMAGE_WIDTH, RESIZE_IMAGES, CONVERT_IMAGES, CONVERT_IMAGES_TO_FILETYPE, DITHERING_ALGORITHM
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), "cached_images")
-MAX_WIDTH = 512
-MAX_HEIGHT = 342
 USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
 
 def is_image_url(url):
-    mime_type, _ = mimetypes.guess_type(url)
-    return mime_type and mime_type.startswith('image/')
+	mime_type, _ = mimetypes.guess_type(url)
+	return mime_type and mime_type.startswith('image/')
 
 def optimize_image(image_data):
-    img = Image.open(io.BytesIO(image_data))
-    
-    if img.mode != 'RGBA':
-        img = img.convert('RGBA')
-    
-    background = Image.new('RGBA', img.size, (255, 255, 255, 255))
-    img = Image.alpha_composite(background, img)
-    img = img.convert('RGB')
-    
-    width, height = img.size
-    if width > MAX_WIDTH or height > MAX_HEIGHT:
-        ratio = min(MAX_WIDTH / width, MAX_HEIGHT / height)
-        new_size = (int(width * ratio), int(height * ratio))
-        img = img.resize(new_size, Image.LANCZOS)
-    
-    img = img.convert("L")
-    img = img.convert("1", dither=Image.FLOYDSTEINBERG)
-    
-    output = io.BytesIO()
-    img.save(output, format="GIF", optimize=True)
-    return output.getvalue()
+	try:
+		img = Image.open(io.BytesIO(image_data))
+		
+		# Convert RGBA images to RGB with white background
+		if img.mode == 'RGBA':
+			background = Image.new('RGB', img.size, (255, 255, 255))
+			background.paste(img, mask=img.split()[3])
+			img = background
+		elif img.mode != 'RGB':
+			img = img.convert('RGB')
+		
+		# Resize if enabled and necessary
+		if RESIZE_IMAGES:
+			width, height = img.size
+			if width > MAX_IMAGE_WIDTH or height > MAX_IMAGE_HEIGHT:
+				ratio = min(MAX_IMAGE_WIDTH / width, MAX_IMAGE_HEIGHT / height)
+				new_size = (int(width * ratio), int(height * ratio))
+				img = img.resize(new_size, Image.Resampling.LANCZOS)
+		
+		# Convert format if enabled
+		if CONVERT_IMAGES:
+			if CONVERT_IMAGES_TO_FILETYPE.lower() == 'gif':
+				# For black and white GIF
+				img = img.convert("L")  # Convert to grayscale first
+				dither_method = Image.Dither.FLOYDSTEINBERG if DITHERING_ALGORITHM.upper() == 'FLOYDSTEINBERG' else None
+				img = img.convert("1", dither=dither_method)
+			else:
+				# For other format conversions
+				img = img.convert(img.mode)
+		
+		output = io.BytesIO()
+		save_format = CONVERT_IMAGES_TO_FILETYPE.upper() if CONVERT_IMAGES else img.format
+		img.save(output, format=save_format, optimize=True)
+		return output.getvalue()
+		
+	except Exception as e:
+		print(f"Error optimizing image: {str(e)}")
+		return image_data
 
 def fetch_and_cache_image(url, content=None):
-    try:
-        print(f"Processing image: {url}")
-        
-        file_name = hashlib.md5(url.encode()).hexdigest() + ".gif"
-        file_path = os.path.join(CACHE_DIR, file_name)
-        
-        if not os.path.exists(file_path):
-            print(f"Optimizing and caching image: {url}")
-            if content is None:
-                response = requests.get(url, stream=True, headers={"User-Agent": USER_AGENT})
-                response.raise_for_status()
-                content = response.content
-            
-            optimized_image = optimize_image(content)
-            with open(file_path, 'wb') as f:
-                f.write(optimized_image)
-        else:
-            print(f"Image already cached: {url}")
-        
-        cached_url = f"/cached_image/{file_name}"
-        print(f"Cached URL: {cached_url}")
-        return cached_url
-    except Exception as e:
-        print(f"Error processing image: {url}, Error: {str(e)}")
-        return None
+	try:
+		print(f"Processing image: {url}")
+		
+		# Generate filename with appropriate extension
+		extension = CONVERT_IMAGES_TO_FILETYPE.lower() if CONVERT_IMAGES else "gif"
+		file_name = hashlib.md5(url.encode()).hexdigest() + f".{extension}"
+		file_path = os.path.join(CACHE_DIR, file_name)
+		
+		if not os.path.exists(file_path):
+			print(f"Optimizing and caching image: {url}")
+			if content is None:
+				response = requests.get(url, stream=True, headers={"User-Agent": USER_AGENT})
+				response.raise_for_status()
+				content = response.content
+			
+			# Only process if image conversion is enabled
+			if CONVERT_IMAGES or RESIZE_IMAGES:
+				optimized_image = optimize_image(content)
+			else:
+				optimized_image = content
+				
+			with open(file_path, 'wb') as f:
+				f.write(optimized_image)
+		else:
+			print(f"Image already cached: {url}")
+		
+		cached_url = f"/cached_image/{file_name}"
+		print(f"Cached URL: {cached_url}")
+		return cached_url
+		
+	except Exception as e:
+		print(f"Error processing image: {url}, Error: {str(e)}")
+		return None
+
+# Ensure cache directory exists
+if not os.path.exists(CACHE_DIR):
+	os.makedirs(CACHE_DIR)


### PR DESCRIPTION
in config.py:
- add WHITELISTED_DOMAINS list, which allows users to specify domains that should not be simplified
- add PRESET string, which allows users to quickly switch between settings tuned for compatibility with different browsers
- add SIMPLIFY_HTML boolean, which conditionally enables/disables tag and attribute stripping
- add TAGS_TO_STRIP and ATTRIBUTES_TO_STRIP lists, which allow users to selectively strip tags and attributes unsupported by their browser, thus increasing load times on vintage machines
- add image optimization settings (CAN_RENDER_INLINE_IMAGES, RESIZE_IMAGES, MAX_IMAGE_WIDTH, MAX_IMAGE_HEIGHT, CONVERT_IMAGES, CONVERT_IMAGES_TO_FILETYPE, DITHERING_ALGORITHM)
- add WEB_SIMULATOR_PROMPT_ADDENDUM, which is appended to the existing web simulator SYSTEM_PROMPT to provide further instructions/context
- add CONVERT_CHARACTERS boolean, which conditionally enables/disables character conversion according to the CONVERSION_TABLE list

in /presets:
- add wii_internet_channel preset, tuned for compatibility with the Nintendo Wii Internet Channel (based on Opera 9)
- add macweb2 preset, tuned for compatibility with vintage Macintosh computers (specifically, TradeWave's MacWeb 2.0 browser)

waybackmachine.py:
- rewrote extension to request pages from the Internet Archive directly (removed waybackpy dependency)
- pages load much faster and rate limiting seems to have been alleviated

utils/html_utils.py:
- convert https:// urls in CSS and JavaScript files to http://