### PR TITLE
Fix missing comma in example config

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -19,7 +19,7 @@ ENABLED_EXTENSIONS = [
 	#"hunterirving",
 	#"kagi",
 	#"mistral",
-	#"notyoutube"
+	#"notyoutube",
 	#"npr",
 	#"reddit",
 	#"waybackmachine",


### PR DESCRIPTION
In the example configuration file, `"notyoutube"` is missing a trailing comma, so if you enable it and then also enable an extension located after it, Macproxy will fail to start because Python will try to combine the strings:

```
Creating python venv for Macproxy Plus...
Activating venv...
Installing base requirements.txt...
No additional requirements for enabled extensions.
Starting Macproxy Plus...
Enabled Extensions:
hackaday
hacksburg
hunterirving
kagi
notyoutubenpr
Traceback (most recent call last):
  File "/Users/srs/Desktop/macproxy_plus/proxy.py", line 137, in <module>
    module = __import__(f"extensions.{ext}.{ext}", fromlist=[''])
ModuleNotFoundError: No module named 'extensions.notyoutubenpr'
```

This PR just adds that comma :) 