### PR TITLE
Support for transcoding SVG images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@ Jinja2==3.0.3
 MarkupSafe==2.0.1
 Werkzeug==2.0.3
 beautifulsoup4==4.10.0
+html5lib==1.1
 itsdangerous==2.0.1
+Pillow==11.0.0
+pillow-svg @ git+https://github.com/smallsco/pillow-svg.git@6b58c2a2d8502d07770ce81cea56ed68e266a6f1
 requests==2.26.0
-Pillow

--- a/utils/html_utils.py
+++ b/utils/html_utils.py
@@ -1,8 +1,21 @@
+# Standard library imports
+import copy
+import hashlib
+import html
+import re
 
+# Third-party imports
 from bs4 import BeautifulSoup
 from bs4.formatter import HTMLFormatter
-import re
-import html
+from flask import current_app, url_for
+
+# First-party imports
+from utils.image_utils import fetch_and_cache_image
+from utils.system_utils import load_preset
+
+# Get config
+config = load_preset()
+
 
 class URLAwareHTMLFormatter(HTMLFormatter):
 	def __init__(self, *args, **kwargs):
@@ -66,7 +79,9 @@ def transcode_html(html, url=None, whitelisted_domains=None, simplify_html=False
 				replacement = replacement.decode("utf-8")
 			html = html.replace(key, replacement)
 
-	soup = BeautifulSoup(html, "html.parser")
+	# The html5lib parser is required in order to preserve case-sensitivity of
+	# tags. Using html.parser will corrupt SVGs and possibly other XML tags.
+	soup = BeautifulSoup(html, "html5lib")
 
 	# Contents of <pre> tags should always use HTML entities
 	for tag in soup.find_all(['pre']):
@@ -80,7 +95,7 @@ def transcode_html(html, url=None, whitelisted_domains=None, simplify_html=False
 				tag['src'] = tag['src'].replace('https://', 'http://')
 			elif tag['src'].startswith('//'):  # Handle protocol-relative URLs
 				tag['src'] = 'http:' + tag['src']
-				
+
 		# Handle href attributes
 		if 'href' in tag.attrs:
 			if tag['href'].startswith('https://'):
@@ -115,6 +130,70 @@ def transcode_html(html, url=None, whitelisted_domains=None, simplify_html=False
 	for tag in soup.find_all(['style', 'link']):
 		if tag.string:
 			tag.string = tag.string.replace('https://', 'http://')
+
+	# Handle inline SVGs - first pass
+	# if any SVG has a child element containing <use href="#value"> or
+	# <use xlink:href="#value"> then we need to find _another_ SVG on the page
+	# with a child element containing <symbol id="value">, and replace the
+	# contents of the first element with the contents of the second. If the
+	# symbol tag defines a viewport, that viewport needs to be copied to the
+	# parent of the use tag (which should be a svg tag)
+	for use_tag in soup.find_all(['use']):
+		attrs = use_tag.attrs
+		if 'href' in attrs:
+			attr = 'href'
+		elif 'xlink:href' in attrs:
+			attr = 'xlink:href'
+		symbol_tag = soup.find("symbol", {"id": use_tag[attr][1:]})
+		if 'viewBox' in symbol_tag.attrs and use_tag.parent.name == 'svg' and 'viewBox' not in use_tag.parent.attrs:
+			use_tag.parent["viewBox"] = symbol_tag["viewBox"]
+		symbol_tag_copy = copy.copy(symbol_tag)
+		use_tag.replace_with(symbol_tag_copy)
+		symbol_tag_copy.unwrap()
+
+	# Handle inline SVGs - second pass
+	# Fetch, cache, and convert them - then replace the inline <svg> tag with
+	# an <img> tag whose src attribute points to this proxy _itself_.
+	for tag in soup.find_all(['svg']):
+
+		# Set height and width equal to the viewport if one is not specified
+		svg_attrs = tag.attrs
+		if "height" not in svg_attrs and "viewBox" in svg_attrs:
+			view_box = svg_attrs["viewBox"].split(" ")
+			tag["height"] = view_box[3]
+		if "width" not in svg_attrs and "viewBox" in svg_attrs:
+			view_box = svg_attrs["viewBox"].split(" ")
+			tag["width"] = view_box[2]
+
+		# Convert it to a gif (or other specified format)
+		fake_url = hashlib.md5(str(tag).encode()).hexdigest()
+		convert = config.CONVERT_IMAGES
+		convert_to = config.CONVERT_IMAGES_TO_FILETYPE
+		fetch_and_cache_image(
+			fake_url,
+			str(tag).encode('utf-8'),
+			resize=config.RESIZE_IMAGES,
+			max_width=config.MAX_IMAGE_WIDTH,
+			max_height=config.MAX_IMAGE_HEIGHT,
+			convert=convert,
+			convert_to=convert_to,
+			dithering=config.DITHERING_ALGORITHM,
+			hash_url=False,
+		)
+		extension = convert_to.lower() if convert and convert_to else "gif"
+
+		# The _external=True attribute of `url_for` doesn't work here, and will
+		# always return `localhost` instead of our host IP / port. So grab that
+		# info from the app config directly and prepend it to a relative URL instead.
+		relative_url = url_for('serve_cached_image', filename=f"{fake_url}.{extension}")
+		url = f"http://{current_app.config['MACPROXY_HOST_AND_PORT']}{relative_url}"
+		img_attrs = {"src": url}
+		if "height" in svg_attrs:
+			img_attrs["height"] = svg_attrs["height"]
+		if "width" in svg_attrs:
+			img_attrs["width"] = svg_attrs["width"]
+		img = soup.new_tag("img", **img_attrs)
+		tag.replace_with(img)
 
 	# Use the custom formatter when converting the soup back to a string
 	html = soup.decode(formatter=URLAwareHTMLFormatter())

--- a/utils/system_utils.py
+++ b/utils/system_utils.py
@@ -16,7 +16,7 @@ def load_preset():
 		return config
 
 	preset_name = config.PRESET
-	preset_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'presets', preset_name)
+	preset_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../presets', preset_name)
 	preset_file = os.path.join(preset_dir, f"{preset_name}.py")
 
 	if not os.path.exists(preset_dir):

--- a/utils/system_utils.py
+++ b/utils/system_utils.py
@@ -1,0 +1,94 @@
+# Standard Library imports
+import os
+
+def load_preset():
+	# Try to import config.py first
+	try:
+		import config
+	except ModuleNotFoundError:
+		print("config.py not found, exiting.")
+		quit()
+
+	"""
+	Load preset configuration and override default settings if a preset is specified
+	"""
+	if not hasattr(config, 'PRESET') or not config.PRESET:
+		return config
+
+	preset_name = config.PRESET
+	preset_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'presets', preset_name)
+	preset_file = os.path.join(preset_dir, f"{preset_name}.py")
+
+	if not os.path.exists(preset_dir):
+		print(f"Error: Preset directory not found: {preset_dir}")
+		print(f"Make sure the preset '{preset_name}' exists in the presets directory")
+		quit()
+
+	if not os.path.exists(preset_file):
+		print(f"Error: Preset file not found: {preset_file}")
+		print(f"Make sure {preset_name}.py exists in the {preset_name} directory")
+		quit()
+
+	try:
+		# Import the preset module
+		import importlib.util
+		spec = importlib.util.spec_from_file_location(preset_name, preset_file)
+		preset_module = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(preset_module)
+
+		# List of variables that can be overridden by presets
+		override_vars = [
+			'SIMPLIFY_HTML',
+			'TAGS_TO_STRIP',
+			'TAGS_TO_UNWRAP',
+			'ATTRIBUTES_TO_STRIP',
+			'CAN_RENDER_INLINE_IMAGES',
+			'RESIZE_IMAGES',
+			'MAX_IMAGE_WIDTH',
+			'MAX_IMAGE_HEIGHT',
+			'CONVERT_IMAGES',
+			'CONVERT_IMAGES_TO_FILETYPE',
+			'DITHERING_ALGORITHM',
+			'WEB_SIMULATOR_PROMPT_ADDENDUM',
+			'CONVERT_CHARACTERS',
+			'CONVERSION_TABLE'
+		]
+
+		changes_made = False
+		# Override config variables with preset values
+		for var in override_vars:
+			if hasattr(preset_module, var):
+				preset_value = getattr(preset_module, var)
+				if not hasattr(config, var) or getattr(config, var) != preset_value:
+					changes_made = True
+					old_value = getattr(config, var) if hasattr(config, var) else None
+					setattr(config, var, preset_value)
+					
+					# Format the values for printing
+					def format_value(val):
+						if isinstance(val, (list, dict)):
+							return str(val)
+						elif isinstance(val, str):
+							return f"'{val}'"
+						else:
+							return str(val)
+					if old_value is None:
+						val = str(format_value(preset_value)).replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
+						truncated = val[:100] + ('...' if len(val) > 100 else '')
+						print(f"Preset '{preset_name}' set {var} to {truncated}")
+					else:
+						old_val = str(format_value(old_value)).replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
+						new_val = str(format_value(preset_value)).replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
+						old_truncated = old_val[:100] + ('...' if len(old_val) > 100 else '')
+						new_truncated = new_val[:100] + ('...' if len(new_val) > 100 else '')
+						print(f"Preset '{preset_name}' changed {var} from {old_truncated} to {new_truncated}")
+		if changes_made:
+			print(f"Successfully loaded preset: {preset_name}")
+		else:
+			print(f"Loaded preset '{preset_name}' (no changes were necessary)")
+
+		return config
+
+	except Exception as e:
+		print(f"Error loading preset '{preset_name}': {str(e)}")
+		quit()


### PR DESCRIPTION
(totally understand if you don't want to merge this one as it's fairly complex!)

This PR adds support for transcoding SVG images. This is done through the use of a third-party library, `pillow-svg` (https://github.com/jlwoolf/pillow-svg/) that adds support to Pillow for reading and writing SVG images.

For SVG images that are loaded via an `<img>` tag, this transcoding happens more-or-less in the same way that Macproxy does for any other image - the only real "gotcha" here is that `pillow-svg` doesn't support loading SVGs directly from a byte stream, so we have to save the SVG to a temporary file first before it can be transcoded. Not a big deal.

For SVG images that are loaded inline, via an `<svg>` tag directly embedded into the HTML, well that's where things get a bit more complicated:
 - Inline SVGs can reference other inline SVGs on the page, so we need to find those references and replace them with a copy of the SVG content in a "first pass".
 - Then, in a "second pass" we grab each `<svg>` tag and its contents and pass it to the `fetch_and_cache_image` function to do the actual transcoding and caching.
 - The `<svg>` tag and contents will be replaced by a new `<img>` tag that points directly to the proxy IP to load the image, rather than the IP/hostname of the site we are visiting.

Major code changes:
 - I had to implement a new function to get the proxy IP, since often it will just be `0.0.0.0` and that won't work in an `<img>` tag!
 - Because `fetch_and_cache_image` can now be called from `html_utils.py`, that file needs access to the config object in order to get the correct parameters to the function call. So I updated the `load_preset` function to return the config object, and moved it into a new utility file, `system_utils.py`. This function is now called from both `proxy.py` and `html_utils.py` when the server starts up.
 - I found a bug in `pillow-svg` that caused the `inkscape` renderer to not work correctly, which I've fixed in my fork of that library. So, the `requirements.txt` in Macproxy is pointing to my fork as the original repo hasn't been updated in a long time (I opened a PR there anyway, but don't have high hopes for it)
 - The BeautifulSoup parser was changed from `html.parser` to `html5lib`. This is required because `html.parser` outputs all tags in lowercase - but SVG, being a descendent of XML rather than of HTML has mandatory case-sensitive tags, and if they are converted to lowercase then the resulting image will be corrupted. `html5lib` preserves case sensitivity at a small performance cost, but it's not really noticeable when you're targeting vintage computers. Also, I only made this change in `transcode_html`, other places in the code continue to use `html.parser`.
 - The imports are organized now for readability :) 