### PR TITLE
Ensure that the contents of <pre> tags use HTML entities

### DIFF
--- a/utils/html_utils.py
+++ b/utils/html_utils.py
@@ -67,7 +67,11 @@ def transcode_html(html, url=None, whitelisted_domains=None, simplify_html=False
 			html = html.replace(key, replacement)
 
 	soup = BeautifulSoup(html, "html.parser")
-	
+
+	# Contents of <pre> tags should always use HTML entities
+	for tag in soup.find_all(['pre']):
+		tag.replace_with(str(tag))
+
 	# Always convert HTTPS to HTTP regardless of whitelist status
 	for tag in soup(['link', 'script', 'img', 'a', 'iframe']):
 		# Handle src attributes


### PR DESCRIPTION
The contents of any `<pre>` tags on a page should be using HTML entities (i.e. `&lt;` instead of `<`).

Currently, the character conversion process that happens during transcoding is turning these entities back into the original characters, which then causes BeautifulSoup to interpret them as actual tags.

This PR will fix that!