### PR TITLE
Removed deprecated startup arguments

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -367,20 +367,5 @@ if __name__ == "__main__":
 		action="store",
 		help="Port number the web server will run on",
 	)
-	parser.add_argument(
-		"--user-agent",
-		type=str,
-		default=USER_AGENT,
-		action="store",
-		help="Spoof as a particular web browser, e.g. \"Mozilla/5.0\"",
-	)
-	parser.add_argument(
-		"--html-formatter",
-		type=str,
-		choices=["minimal", "html", "html5"],
-		default="html5",
-		action="store",
-		help="The BeautifulSoup html formatter that Macproxy will use",
-	)
 	arguments = parser.parse_args()
 	app.run(host="0.0.0.0", port=arguments.port, debug=False)


### PR DESCRIPTION
I removed the `--user-agent` and `--html-formatter` startup options, as they no longer do anything:

The user agent is configured by the `USER_AGENT` constant, and is configured on a per-extension basis (as well as being set both for the proxy in general and separately for image downloading). It might be better to move this into the config file at some point.

The HTML formatter is hardcoded to use the `URLAwareHTMLFormatter` class, and so the startup option does nothing. I don't think it makes sense for the user to be able to change this.