### PR TITLE
Treat Werkzeug response objects the same as Flask response objects during response processing

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import requests
 from flask import Flask, request, session, g, abort, Response, send_from_directory
 from werkzeug.serving import get_interface_ip
+from werkzeug.wrappers.response import Response as WerkzeugResponse
 
 # First-party imports
 from utils.html_utils import transcode_html, transcode_content
@@ -151,7 +152,7 @@ def process_response(response, url):
 			content = response[0]
 			status_code = 200
 			headers = {}
-	elif isinstance(response, Response):
+	elif isinstance(response, (Response, WerkzeugResponse)):
 		return response
 	else:
 		content = response


### PR DESCRIPTION
If you have an extension that returns a redirect response for some request, i.e.

```
from flask import redirect

DOMAIN="example.com"

def handle_request(request):
    parsed_url = urlparse(request.url)
    if parsed_url.path == '/':
        return redirect(f"http://{DOMAIN}/some/log/path")
```

Then Flask will return a `werkzeug.wrappers.response.Response` object, rather than a `flask.Response` object. This in turn causes MacProxy to raise a HTTP 500 error because it thinks it needs to postprocess the content:

```
[2025-01-04 14:32:53,992] ERROR in app: Exception on / [GET]
Traceback (most recent call last):
  File "/Users/srs/Documents/macproxy_plus/venv/lib/python3.9/site-packages/flask/app.py", line 2073, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/srs/Documents/macproxy_plus/venv/lib/python3.9/site-packages/flask/app.py", line 1518, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/srs/Documents/macproxy_plus/venv/lib/python3.9/site-packages/flask/app.py", line 1516, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/srs/Documents/macproxy_plus/venv/lib/python3.9/site-packages/flask/app.py", line 1502, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users/srs/Documents/macproxy_plus/proxy.py", line 94, in handle_request
    return process_response(response, request.url)
  File "/Users/srs/Documents/macproxy_plus/proxy.py", line 216, in process_response
    content = transcode_html(
  File "/Users/srs/Documents/macproxy_plus/utils/html_utils.py", line 80, in transcode_html
    html = html.replace(key, replacement)
AttributeError: 'Response' object has no attribute 'replace'
```

So, here's a small fix that simply checks to see if we have either a Flask _or_ Werkzeug response, and return directly in that case.