### PR TITLE
address issue #18 (strip transfer-encoding headers)

### DIFF
--- a/proxy.py
+++ b/proxy.py
@@ -229,7 +229,7 @@ def process_response(response, url):
 
 	response = Response(content, status_code)
 	for key, value in headers.items():
-		if key.lower() not in ['content-encoding', 'content-length']:
+		if key.lower() not in ["content-encoding", "content-length", "transfer-encoding"]:
 			response.headers[key] = value
 
 	print("Finished processing response")


### PR DESCRIPTION
strip transfer-encoding header which caused content delivery failures in retro browsers (resolves #18)